### PR TITLE
Add codebase overview report

### DIFF
--- a/REPORT_2025-07-24T17-47-22Z.md
+++ b/REPORT_2025-07-24T17-47-22Z.md
@@ -1,0 +1,32 @@
+# Codebase Overview
+
+## Purpose
+`verl` is a reinforcement learning (RL) training library for large language models (LLMs). The README describes it as a flexible, efficient and production-ready framework derived from the HybridFlow paper, supporting various RL algorithms and integrations with FSDP, Megatron-LM, vLLM and more.
+
+## Repository Structure
+- **Root contents:**
+  - `docs/` documentation sources
+  - `examples/` runnable training scripts
+  - `recipe/` reference training recipes
+  - `verl/` main Python package
+  - `tests/` unit and integration tests
+  - project metadata such as `pyproject.toml` and contributor guides
+- **`verl/` package:** contains training logic (`trainer`), worker implementations (`workers`), a communication protocol (`protocol.py`), experimental modules and utilities.
+
+## Key Features
+The README highlights features such as FSDP/FSDP2/Megatron training, vLLM/SGLang rollout generation, multiple RL algorithms (PPO, GRPO, etc.), multi-modal support, LoRA RL, and experiment tracking. It also lists upcoming features and integrations.
+
+## Documentation
+`docs/README.md` explains how to build the documentation locally using Sphinx.
+
+## Contribution & Testing
+`CONTRIBUTING.md` describes how to install dependencies, run pre-commit linting and add CI tests. The `tests/README.md` outlines the test layout and how workflows are organized.
+
+## Learning Path
+New contributors should:
+1. Read the README for high-level concepts and features.
+2. Browse `examples/` for runnable training scripts.
+3. Inspect `verl/trainer` and `verl/workers` to understand the training loop and distributed setup.
+4. Review the documentation under `docs/` and build it locally.
+5. See `CONTRIBUTING.md` and `tests/README.md` for guidelines on development and testing.
+


### PR DESCRIPTION
## Summary
- add timestamped codebase overview report for newcomers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68826fdbacc8832fbad332e259da7742